### PR TITLE
Setting to list/filter users based on wordpress roles

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP-ISPConfig3
  * Description: ISPConfig3 plugin allows you to register customers through wordpress frontend using shortcodes.
- * Version: 1.3.4
+ * Version: 1.3.5
  * Author: ole1986 <ole.k@web.de>, MachineITSvcs <contact@machineitservices.com>
  * Author URI: https://github.com/ole1986/wp-ispconfig3
  * Text Domain: wp-ispconfig3
@@ -66,7 +66,8 @@ if (!class_exists('WPISPConfig3')) {
                                 Domain: #DOMAIN#\n
                                 Login with your account on http://#HOSTNAME#:8080",
             'default_domain' => 'yourdomain.tld',
-            'sender_name' => 'Your Sevice name'
+            'sender_name' => 'Your Sevice name',
+            'user_roles' => ['customer', 'subscriber']
         ];
 
         /**
@@ -216,9 +217,18 @@ if (!class_exists('WPISPConfig3')) {
                             <?php
                                 self::getField('confirm', 'Send Confirmation', 'checkbox');
                                 self::getField('confirm_subject', 'Confirmation subject');
-                                self::getField('confirm_body', 'Confirmation Body', 'textarea');
+                                self::getField('confirm_body', 'Confirmation Body', 'textarea', ['input_attr' => ['style' => 'width: 340px; height: 150px']]);
                                 self::getField('default_domain', 'Default Domain');
                                 self::getField('sender_name', 'Sender name');
+                            ?>
+                            <h3><?php _e('User Mapping') ?></h3>
+                            <p>Choose the below WordPress user roles to match the clients stored in ISPconfig3</p>
+                            <?php
+                            $roles = wp_roles()->roles;
+                            foreach ($roles as $k => $v) {
+                                $checked = in_array($k, self::$OPTIONS['user_roles']) ? 'checked' : '';
+                                echo "<input type='checkbox' id='user_role_$k' name='user_roles[]' value='$k' $checked /> <label for='user_role_$k'>" . $v['name'] . '</label>&nbsp;';
+                            }
                             ?>
                         </div>
                         <?php do_action('ispconfig_options'); ?>

--- a/manage/ispconfig_database.php
+++ b/manage/ispconfig_database.php
@@ -34,7 +34,7 @@ class IspconfigDatabase
                 <select id="user_login" name="user_login" style="min-width: 200px">
                     <option value="">[select customer]</option>
                 <?php
-                $users = get_users(['role' => 'customer']);
+                $users = get_users(['role__in' => WPISPConfig3::$OPTIONS['user_roles']]);
                 foreach ($users as $u) {
                     $company = get_user_meta($u->ID, 'billing_company', true);
                     $selected = (isset($_GET['user_login']) && $u->user_login == $_GET['user_login'])?'selected':'';

--- a/manage/ispconfig_website.php
+++ b/manage/ispconfig_website.php
@@ -38,7 +38,6 @@ class IspconfigWebsite
     public static function DisplayWebsites()
     {
         $list = new IspconfigWebsiteList();
-        
         $list->prepare_items();
 
         ?>
@@ -53,7 +52,7 @@ class IspconfigWebsite
                 <select id="user_login" name="user_login" style="min-width: 200px">
                     <option value="">[select customer]</option>
                 <?php
-                $users = get_users(['role' => 'customer']);
+                $users = get_users(['role__in' => WPISPConfig3::$OPTIONS['user_roles']]);
                 foreach ($users as $u) {
                     $company = get_user_meta($u->ID, 'billing_company', true);
                     $selected = (isset($_GET['user_login']) && $u->user_login == $_GET['user_login'])?'selected':'';


### PR DESCRIPTION
Since this plugin is not only useful for WooCommerce "customer" roles, we decided to add an option allowing the filter the user list in Websites and Databases based on their wordpress roles (#17 ).

Still it is required that the ISPconfig3 client user matches the wordpress user